### PR TITLE
Мелкий фикс пары багов.

### DIFF
--- a/src/Haxmin.hx
+++ b/src/Haxmin.hx
@@ -459,6 +459,7 @@ class Haxmin {
 				case TId(_): xc = " ".code;
 				case TKw(_): xc = " ".code;
 				case TNu(_): xc = " ".code;
+				case TFlow(fp): if (fp == "}".code) xc = ";".code;
 				default:
 				}
 			case TKw(kw): switch (ltk) {
@@ -502,11 +503,11 @@ class Haxmin {
 				o.writeTo(b);
 				c += o.length;
 			case TSt(o, t, d):
+				b.addChar(d ? "\"".code : "'".code);
 				if (t != 0) {
 					b.addSub(t > 0 ? get_ : set_, 0);
 					c += (t > 0 ? get_ : set_).length;
 				}
-				b.addChar(d ? "\"".code : "'".code);
 				o.writeTo(b);
 				b.addChar(d ? "\"".code : "'".code);
 				c += o.length + 2;


### PR DESCRIPTION
1 . Случай:

``` javascript
myVar.myField = {ququ:'value'}
myFunc = function() {...
```

корректен с точки зрения JS. И генерируется компилятором хэкса
(тут, в частности: https://github.com/HaxeFoundation/haxe/blob/6568450332b7c3d72c3d21978bedd979692e2ec9/genjs.ml#L1011)
Но при удалении line break получаем:

``` javascript
a.b={c:"value"}d=function(){...
```

что уже некорректно. Таблэтка: "если перед TId | TNu находится TFlow в виде '}', то всобачиваем ';' в extra character"

2 . Случай:

``` javascript
myVar.myField = {get_SOMETHING:"get_SOMETHING"}
```

у тебя собирается в

``` javascript
//(с ключом /nr)
myVar.myField={get_SOMETHING:get_"SOMETHING"}
```

что, очевидно, неверно. Переставил кавычку.

Пардон, если чего-то не учёл и сломал логику. :)
